### PR TITLE
Update documentation page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,12 +109,12 @@
 
 	For Conference Mode:
 	<pre>
-    https://cppform.cierecloud.com/timer/<i>track_name0</i>/<i>track_name1</i>/?url=<i>url_of_data_file</i>&h&s
+    https://conference-infra.github.io/timer-app/timer/<i>track_name0</i>/<i>track_name1</i>/?url=<i>url_of_data_file</i>&h&s
 </pre>
 
 	For One-Off Mode:
 	<pre>
-    https://cppform.cierecloud.com/timer/<i>track_name0</i>/<i>track_name1</i>/?end=<i>end_time</i>&h&s
+    https://conference-infra.github.io/timer-app/timer/<i>track_name0</i>/<i>track_name1</i>/?end=<i>end_time</i>&h&s
 </pre>
 
 	where:
@@ -131,9 +131,9 @@
 
 	<p>If neither the url nor the end parameter is passed, this file is returned.</p>
 
-	<p>If the h parameter is optional and can be expressed as &show_hours.</p>
+	<p>The h parameter is optional and can be expressed as &show_hours.</p>
 
-	<p>If the s parameter is optional and can be expressed as &show_seconds.</p>
+	<p>The s parameter is optional and can be expressed as &show_seconds.</p>
 
 	Please contact <a href="mailto:jon@slashslash.info">the maintainer</a> to report issues. Thank you.
 </body>


### PR DESCRIPTION
Changed the URL from cppform.cierecloud.com to conference-infra.github.io/timer-app

Fixed grammar related to "h" and "s" parameters.