### PR TITLE
Update CppCon 2025 with half-sessions and early open-content.

### DIFF
--- a/data/CppCon2025.json
+++ b/data/CppCon2025.json
@@ -1,294 +1,355 @@
 [
-   {
-       "begin": "2025-09-13T09:00:00-06:00",
-       "duration": 105,
-       "name": "Saturday pre-conference class"
-   },
-   {
-       "begin": "2025-09-13T11:00:00-06:00",
-       "duration": 105,
-       "name": "Saturday pre-conference class"
-   },
-   {
-       "begin": "2025-09-13T13:30:00-06:00",
-       "duration": 90,
-       "name": "Saturday pre-conference class"
-   },
-   {
-       "begin": "2025-09-13T15:15:00-06:00",
-       "duration": 105,
-       "name": "Saturday pre-conference class"
-   },
-   {
-       "begin": "2025-09-14T09:00:00-06:00",
-       "duration": 105,
-       "name": "Sunday pre-conference class"
-   },
-   {
-       "begin": "2025-09-14T11:00:00-06:00",
-       "duration": 105,
-       "name": "Sunday pre-conference class"
-   },
-   {
-       "begin": "2025-09-14T13:30:00-06:00",
-       "duration": 90,
-       "name": "Sunday pre-conference class"
-   },
-   {
-       "begin": "2025-09-14T15:15:00-06:00",
-       "duration": 105,
-       "name": "Sunday pre-conference class"
-   },
-   {
-       "begin": "2025-09-14T20:00:00-06:00",
-       "duration": 120,
-       "name": "Registration Reception"
-   },
-   {
-       "begin": "2025-09-15T08:45:00-06:00",
-       "duration": 15,
-       "name": "welcome"
-   },
-   {
-       "begin": "2025-09-15T09:00:00-06:00",
-       "duration": 90,
-       "name": "opening plenary"
-   },
-   {
-       "begin": "2025-09-15T10:30:00-06:00",
-       "duration": 10,
-       "name": "conference group photo"
-   },
-   {
-       "begin": "2025-09-15T11:00:00-06:00",
-       "duration": 60,
-       "name": "Monday first breakout"
-   },
-   {
-       "begin": "2025-09-15T12:30:00-06:00",
-       "duration": 60,
-       "name": "Monday lunch / Open Content"
-   },
-   {
-       "begin": "2025-09-15T14:00:00-06:00",
-       "duration": 60,
-       "name": "Monday second breakout"
-   },
-   {
-       "begin": "2025-09-15T15:15:00-06:00",
-       "duration": 60,
-       "name": "Monday third breakout"
-   },
-   {
-       "begin": "2025-09-15T16:45:00-06:00",
-       "duration": 60,
-       "name": "Monday fourth breakout"
-   },
-   {
-       "begin": "2025-09-15T20:30:00-06:00",
-       "duration": 90,
-       "name": "Monday evening Open Content"
-   },
-   {
-       "begin": "2025-09-16T07:45:00-06:00",
-       "duration": 60,
-       "name": "Tuesday morning Open Content"
-   },
-   {
-       "begin": "2025-09-16T09:00:00-06:00",
-       "duration": 60,
-       "name": "Tuesday first breakout"
-   },
-   {
-       "begin": "2025-09-16T10:30:00-06:00",
-       "duration": 90,
-       "name": "Tuesday plenary"
-   },
-   {
-       "begin": "2025-09-16T12:30:00-06:00",
-       "duration": 60,
-       "name": "Tuesday lunch Open Content"
-   },
-   {
-       "begin": "2025-09-16T14:00:00-06:00",
-       "duration": 60,
-       "name": "Tuesday second breakout"
-   },
-   {
-       "begin": "2025-09-16T15:15:00-06:00",
-       "duration": 60,
-       "name": "Tuesday third breakout"
-   },
-   {
-       "begin": "2025-09-16T16:45:00-06:00",
-       "duration": 60,
-       "name": "Tuesday fourth breakout"
-   },
-   {
-       "begin": "2025-09-16T20:30:00-06:00",
-       "duration": 90,
-       "name": "Tuesday evening Open Content"
-   },
-   {
-       "begin": "2025-09-17T07:45:00-06:00",
-       "duration": 60,
-       "name": "Wednesday Open Content"
-   },
-   {
-       "begin": "2025-09-17T09:00:00-06:00",
-       "duration": 60,
-       "name": "Wednesday first breakout"
-   },
-   {
-       "begin": "2025-09-17T10:30:00-06:00",
-       "duration": 90,
-       "name": "Wednesday plenary"
-   },
-   {
-       "begin": "2025-09-17T12:30:00-06:00",
-       "duration": 60,
-       "name": "Wednesday lunch Open Content"
-   },
-   {
-       "begin": "2025-09-17T14:00:00-06:00",
-       "duration": 60,
-       "name": "Wednesday second breakout"
-   },
-   {
-       "begin": "2025-09-17T15:15:00-06:00",
-       "duration": 60,
-       "name": "Wednesday third breakout"
-   },
-   {
-       "begin": "2025-09-17T16:45:00-06:00",
-       "duration": 60,
-       "name": "Wednesday fourth breakout"
-   },
-   {
-       "begin": "2025-09-17T20:30:00-06:00",
-       "duration": 90,
-       "name": "Wednesday evening Open Content"
-   },
-   {
-       "begin": "2025-09-18T07:45:00-06:00",
-       "duration": 60,
-       "name": "Thursday morning Open Content"
-   },
-   {
-       "begin": "2025-09-18T09:00:00-06:00",
-       "duration": 60,
-       "name": "Thursday first breakout"
-   },
-   {
-       "begin": "2025-09-18T10:30:00-06:00",
-       "duration": 90,
-       "name": "Thursday plenary"
-   },
-   {
-       "begin": "2025-09-18T12:30:00-06:00",
-       "duration": 60,
-       "name": "Thursday lunch Open Content"
-   },
-   {
-       "begin": "2025-09-18T14:00:00-06:00",
-       "duration": 60,
-       "name": "Thursday second breakout"
-   },
-   {
-       "begin": "2025-09-18T15:15:00-06:00",
-       "duration": 60,
-       "name": "Thursday third breakout"
-   },
-   {
-       "begin": "2025-09-18T16:45:00-06:00",
-       "duration": 60,
-       "name": "Thursday fourth breakout"
-   },
-   {
-       "begin": "2025-09-18T20:30:00-06:00",
-       "duration": 90,
-       "name": "Thursday evening Open Content"
-   },
-   {
-       "begin": "2025-09-19T07:45:00-06:00",
-       "duration": 45,
-       "name": "Friday morning Open Content"
-   },
-   {
-       "begin": "2025-09-19T09:00:00-06:00",
-       "duration": 60,
-       "name": "Friday first breakout"
-   },
-   {
-       "begin": "2025-09-19T10:30:00-06:00",
-       "duration": 60,
-       "name": "Friday second breakout"
-   },
-   {
-       "begin": "2025-09-19T12:00:00-06:00",
-       "duration": 60,
-       "name": "Friday lunch Open Content"
-   },
-   {
-       "begin": "2025-09-19T13:30:00-06:00",
-       "duration": 60,
-       "name": "Friday third breakout"
-   },
-   {
-       "begin": "2025-09-19T14:45:00-06:00",
-       "duration": 60,
-       "name": "Friday fourth breakout"
-   },
-   {
-       "begin": "2025-09-19T16:15:00-06:00",
-       "duration": 90,
-       "name": "closing plenary"
-   },
-   {
-       "begin": "2025-09-19T17:45:00-06:00",
-       "duration": 15,
-       "name": "closing"
-   },
-   {
-       "begin": "2025-09-20T09:00:00-06:00",
-       "duration": 105,
-       "name": "Saturday post-conference class"
-   },
-   {
-       "begin": "2025-09-20T11:00:00-06:00",
-       "duration": 105,
-       "name": "Saturday post-conference class"
-   },
-   {
-       "begin": "2025-09-20T13:30:00-06:00",
-       "duration": 90,
-       "name": "Saturday post-conference class"
-   },
-   {
-       "begin": "2025-09-20T15:15:00-06:00",
-       "duration": 105,
-       "name": "Saturday post-conference class"
-   },
-   {
-       "begin": "2024-09-21T09:00:00-06:00",
-       "duration": 105,
-       "name": "Sunday post-conference class"
-   },
-   {
-       "begin": "2024-09-21T11:00:00-06:00",
-       "duration": 105,
-       "name": "Sunday post-conference class"
-   },
-   {
-       "begin": "2024-09-21T13:30:00-06:00",
-       "duration": 90,
-       "name": "Sunday post-conference class"
-   },
-   {
-       "begin": "2024-09-21T15:15:00-06:00",
-       "duration": 105,
-       "name": "Sunday post-conference class"
-   }
+  {
+    "begin": "2025-09-13T09:00:00-06:00",
+    "duration": 105,
+    "name": "Saturday pre-conference class start"
+  },
+  {
+    "begin": "2025-09-13T11:00:00-06:00",
+    "duration": 105,
+    "name": "Saturday pre-conference class pre-lunch"
+  },
+  {
+    "begin": "2025-09-13T13:30:00-06:00",
+    "duration": 90,
+    "name": "Saturday pre-conference class post-lunch"
+  },
+  {
+    "begin": "2025-09-13T15:15:00-06:00",
+    "duration": 105,
+    "name": "Saturday pre-conference class post-coffee"
+  },
+  {
+    "begin": "2025-09-14T09:00:00-06:00",
+    "duration": 105,
+    "name": "Sunday pre-conference class start"
+  },
+  {
+    "begin": "2025-09-14T11:00:00-06:00",
+    "duration": 105,
+    "name": "Sunday pre-conference class pre-lunch"
+  },
+  {
+    "begin": "2025-09-14T13:30:00-06:00",
+    "duration": 90,
+    "name": "Sunday pre-conference class post-lunch"
+  },
+  {
+    "begin": "2025-09-14T15:15:00-06:00",
+    "duration": 105,
+    "name": "Sunday pre-conference class post-coffee"
+  },
+  {
+    "begin": "2025-09-14T20:00:00-06:00",
+    "duration": 120,
+    "name": "Registration Reception"
+  },
+  {
+    "begin": "2025-09-15T08:00:00-06:00",
+    "duration": 45,
+    "name": "Registration"
+  },
+  {
+    "begin": "2025-09-15T08:45:00-06:00",
+    "duration": 15,
+    "name": "welcome"
+  },
+  {
+    "begin": "2025-09-15T09:00:00-06:00",
+    "duration": 90,
+    "name": "opening plenary"
+  },
+  {
+    "begin": "2025-09-15T10:30:00-06:00",
+    "duration": 15,
+    "name": "conference group photo"
+  },
+  {
+    "begin": "2025-09-15T11:00:00-06:00",
+    "duration": 60,
+    "name": "Monday first breakout"
+  },
+  {
+    "begin": "2025-09-15T12:30:00-06:00",
+    "duration": 60,
+    "name": "Monday lunch / Open Content"
+  },
+  {
+    "begin": "2025-09-15T14:00:00-06:00",
+    "duration": 60,
+    "name": "Monday second breakout"
+  },
+  {
+    "begin": "2025-09-15T15:15:00-06:00",
+    "duration": 60,
+    "name": "Monday third breakout"
+  },
+  {
+    "begin": "2025-09-15T16:45:00-06:00",
+    "duration": 60,
+    "name": "Monday fourth breakout"
+  },
+  {
+    "begin": "2025-09-15T18:30:00-06:00",
+    "duration": 90,
+    "name": "Monday evening / Open Content"
+  },
+  {
+    "begin": "2025-09-15T20:30:00-06:00",
+    "duration": 90,
+    "name": "Monday evening Open Content"
+  },
+  {
+    "begin": "2025-09-16T07:15:00-06:00",
+    "duration": 90,
+    "name": "Tuesday morning Open Content",
+    "tracks": ["full"]
+  },
+  {
+    "begin": "2025-09-16T08:00:00-06:00",
+    "duration": 45,
+    "name": "Tuesday morning Open Content",
+    "tracks": ["half"]
+  },
+  {
+    "begin": "2025-09-16T09:00:00-06:00",
+    "duration": 60,
+    "name": "Tuesday first breakout"
+  },
+  {
+    "begin": "2025-09-16T10:30:00-06:00",
+    "duration": 90,
+    "name": "Tuesday plenary"
+  },
+  {
+    "begin": "2025-09-16T12:30:00-06:00",
+    "duration": 60,
+    "name": "Tuesday lunch Open Content"
+  },
+  {
+    "begin": "2025-09-16T14:00:00-06:00",
+    "duration": 60,
+    "name": "Tuesday second breakout"
+  },
+  {
+    "begin": "2025-09-16T15:15:00-06:00",
+    "duration": 60,
+    "name": "Tuesday third breakout"
+  },
+  {
+    "begin": "2025-09-16T16:45:00-06:00",
+    "duration": 60,
+    "name": "Tuesday fourth breakout"
+  },
+  {
+    "begin": "2025-09-16T20:30:00-06:00",
+    "duration": 90,
+    "name": "Tuesday evening Open Content"
+  },
+  {
+    "begin": "2025-09-17T07:45:00-06:00",
+    "duration": 60,
+    "name": "Wednesday Open Content",
+    "tracks": ["full"]
+  },
+  {
+    "begin": "2025-09-17T08:00:00-06:00",
+    "duration": 45,
+    "name": "Wednesday Open Content",
+    "tracks": ["half"]
+  },
+  {
+    "begin": "2025-09-17T09:00:00-06:00",
+    "duration": 60,
+    "name": "Wednesday first breakout"
+  },
+  {
+    "begin": "2025-09-17T10:30:00-06:00",
+    "duration": 90,
+    "name": "Wednesday plenary"
+  },
+  {
+    "begin": "2025-09-17T12:30:00-06:00",
+    "duration": 60,
+    "name": "Wednesday lunch Open Content"
+  },
+  {
+    "begin": "2025-09-17T14:00:00-06:00",
+    "duration": 60,
+    "name": "Wednesday second breakout"
+  },
+  {
+    "begin": "2025-09-17T15:15:00-06:00",
+    "duration": 60,
+    "name": "Wednesday third breakout",
+    "tracks": ["full"]
+  },
+  {
+    "begin": "2025-09-17T15:15:00-06:00",
+    "duration": 30,
+    "name": "Wednesday third breakout first",
+    "tracks": ["half"]
+  },
+  {
+    "begin": "2025-09-17T15:50:00-06:00",
+    "duration": 30,
+    "name": "Wednesday third breakout second",
+    "tracks": ["half"]
+  },
+  {
+    "begin": "2025-09-17T16:45:00-06:00",
+    "duration": 60,
+    "name": "Wednesday fourth breakout"
+  },
+  {
+    "begin": "2025-09-17T20:30:00-06:00",
+    "duration": 90,
+    "name": "Wednesday evening Open Content"
+  },
+  {
+    "begin": "2025-09-18T07:45:00-06:00",
+    "duration": 60,
+    "name": "Thursday morning Open Content",
+    "tracks": ["full"]
+  },
+  {
+    "begin": "2025-09-18T09:00:00-06:00",
+    "duration": 60,
+    "name": "Thursday first breakout"
+  },
+  {
+    "begin": "2025-09-18T10:30:00-06:00",
+    "duration": 90,
+    "name": "Thursday plenary"
+  },
+  {
+    "begin": "2025-09-18T12:30:00-06:00",
+    "duration": 60,
+    "name": "Thursday lunch Open Content"
+  },
+  {
+    "begin": "2025-09-18T14:00:00-06:00",
+    "duration": 60,
+    "name": "Thursday second breakout"
+  },
+  {
+    "begin": "2025-09-18T14:00:00-06:00",
+    "duration": 30,
+    "name": "Thursday second breakout first",
+    "tracks":["half"]
+  },
+  {
+    "begin": "2025-09-18T14:40:00-06:00",
+    "duration": 30,
+    "name": "Thursday second breakout second",
+    "tracks":["half"]
+  },
+  {
+    "begin": "2025-09-18T15:15:00-06:00",
+    "duration": 60,
+    "name": "Thursday third breakout"
+  },
+  {
+    "begin": "2025-09-18T16:45:00-06:00",
+    "duration": 30,
+    "name": "Thursday fourth breakout first",
+    "tracks":["half"]
+  },
+  {
+    "begin": "2025-09-18T17:20:00-06:00",
+    "duration": 30,
+    "name": "Thursday fourth breakout second",
+    "tracks":["half"]
+  },
+  {
+    "begin": "2025-09-18T16:45:00-06:00",
+    "duration": 60,
+    "name": "Thursday fourth breakout"
+  },
+  {
+    "begin": "2025-09-18T20:30:00-06:00",
+    "duration": 90,
+    "name": "Thursday evening Open Content"
+  },
+  {
+    "begin": "2025-09-19T08:00:00-06:00",
+    "duration": 45,
+    "name": "Friday morning Open Content",
+    "tracks": ["half"]
+  },
+  {
+    "begin": "2025-09-19T09:00:00-06:00",
+    "duration": 60,
+    "name": "Friday first breakout"
+  },
+  {
+    "begin": "2025-09-19T10:30:00-06:00",
+    "duration": 60,
+    "name": "Friday second breakout"
+  },
+  {
+    "begin": "2025-09-19T12:00:00-06:00",
+    "duration": 60,
+    "name": "Friday lunch Open Content"
+  },
+  {
+    "begin": "2025-09-19T13:30:00-06:00",
+    "duration": 60,
+    "name": "Friday third breakout"
+  },
+  {
+    "begin": "2025-09-19T14:45:00-06:00",
+    "duration": 60,
+    "name": "Friday fourth breakout"
+  },
+  {
+    "begin": "2025-09-19T16:15:00-06:00",
+    "duration": 90,
+    "name": "closing plenary"
+  },
+  {
+    "begin": "2025-09-19T17:45:00-06:00",
+    "duration": 15,
+    "name": "closing"
+  },
+  {
+    "begin": "2025-09-20T09:00:00-06:00",
+    "duration": 105,
+    "name": "Saturday post-conference class start"
+  },
+  {
+    "begin": "2025-09-20T11:00:00-06:00",
+    "duration": 105,
+    "name": "Saturday post-conference class pre-lunch"
+  },
+  {
+    "begin": "2025-09-20T13:30:00-06:00",
+    "duration": 90,
+    "name": "Saturday post-conference class post-lunch"
+  },
+  {
+    "begin": "2025-09-20T15:15:00-06:00",
+    "duration": 105,
+    "name": "Saturday post-conference class post-coffee"
+  },
+  {
+    "begin": "2024-09-21T09:00:00-06:00",
+    "duration": 105,
+    "name": "Sunday post-conference class start"
+  },
+  {
+    "begin": "2024-09-21T11:00:00-06:00",
+    "duration": 105,
+    "name": "Sunday post-conference class pre-lunch"
+  },
+  {
+    "begin": "2024-09-21T13:30:00-06:00",
+    "duration": 90,
+    "name": "Sunday post-conference class post-lunch"
+  },
+  {
+    "begin": "2024-09-21T15:15:00-06:00",
+    "duration": 105,
+    "name": "Sunday post-conference class post-coffee"
+  }
 ]
-
-

--- a/to_ics.py
+++ b/to_ics.py
@@ -1,0 +1,53 @@
+###
+# Generated wit ChatGPT
+###
+
+import json
+from datetime import datetime, timedelta
+import pytz
+
+INPUT_FILE = "data/CppCon2025.json"
+OUTPUT_FILE = "cppcon2025.ics"
+
+# Load JSON
+with open(INPUT_FILE) as f:
+    events = json.load(f)
+
+tz = pytz.timezone("America/Denver")
+
+
+def format_dt(dt: datetime) -> str:
+    # Format as UTC for ICS
+    return dt.strftime("%Y%m%dT%H%M%SZ")
+
+
+ics_events = []
+for ev in events:
+    start = datetime.fromisoformat(ev["begin"])
+    if start.tzinfo is None:
+        start = pytz.UTC.localize(start)  # assume UTC if missing
+    start = start.astimezone(tz)
+
+    dur = timedelta(minutes=ev["duration"])
+    end = start + dur
+
+    # ICS requires UTC
+    start_utc = start.astimezone(pytz.UTC)
+    end_utc = end.astimezone(pytz.UTC)
+
+    ics_event = f"""BEGIN:VEVENT
+UID:{ev["name"].replace(" ", "_")}#{ev["tracks"] if "tracks" in ev else ""}
+SEQUENCE:0
+SUMMARY:{ev["name"]} {ev["tracks"] if "tracks" in ev else ""}
+DTSTART:{format_dt(start_utc)}
+DTEND:{format_dt(end_utc)}
+END:VEVENT"""
+    ics_events.append(ics_event)
+
+ics_content = "BEGIN:VCALENDAR\nVERSION:2.0\n" + \
+    "\n".join(ics_events) + "\nEND:VCALENDAR\n"
+
+with open(OUTPUT_FILE, "w") as f:
+    f.write(ics_content)
+
+print(f"ICS file written to {OUTPUT_FILE}")


### PR DESCRIPTION
Includes a new Python script to convert the JSON input into an ICS file that can be loaded into Google calendar (or any calendar software) for visual inspection.